### PR TITLE
Updated manifest to Espruino v91

### DIFF
--- a/public/v1/esp8266/esp12/espruino/manifest.1.90.json
+++ b/public/v1/esp8266/esp12/espruino/manifest.1.90.json
@@ -1,0 +1,26 @@
+{
+  "name": "Espruino",
+  "version": "1v90",
+  "board": "ESP8266",
+  "revision": "ESP-12",
+  "description": "Official Binaries for the Espruino Runtime for the ESP8266 MCU ESP-12",
+  "download": "http://www.espruino.com/files/espruino_1v90.zip",
+  "flash": [
+    {
+      "address": "0x0000",
+      "path": "espruino_1v90_esp8266/boot_v1.6.bin"
+    },
+    {
+      "address": "0x1000",
+      "path": "espruino_1v90_esp8266/espruino_esp8266_user1.bin"
+    },
+    {
+      "address": "0x3FC000",
+      "path": "espruino_1v90_esp8266/esp_init_data_default.bin"
+    },
+    {
+      "address": "0x37E000",
+      "path": "espruino_1v90_esp8266/blank.bin"
+    }
+  ]
+}

--- a/public/v1/esp8266/esp12/espruino/manifest.1.91.json
+++ b/public/v1/esp8266/esp12/espruino/manifest.1.91.json
@@ -1,0 +1,26 @@
+{
+  "name": "Espruino",
+  "version": "1v91",
+  "board": "ESP8266",
+  "revision": "ESP-12",
+  "description": "Official Binaries for the Espruino Runtime for the ESP8266 MCU ESP-12",
+  "download": "http://www.espruino.com/files/espruino_1v91.zip",
+  "flash": [
+    {
+      "address": "0x0000",
+      "path": "espruino_1v91_esp8266/boot_v1.6.bin"
+    },
+    {
+      "address": "0x1000",
+      "path": "espruino_1v91_esp8266/espruino_esp8266_user1.bin"
+    },
+    {
+      "address": "0x3FC000",
+      "path": "espruino_1v91_esp8266/esp_init_data_default.bin"
+    },
+    {
+      "address": "0x37E000",
+      "path": "espruino_1v91_esp8266/blank.bin"
+    }
+  ]
+}

--- a/v1.json
+++ b/v1.json
@@ -4,11 +4,25 @@
             "name": "Espruino",
             "versions": [
                 {
+                    "version": "1v91",
+                    "board": "ESP8266",
+                    "revision": "ESP12",
+                    "manifest": "/v1/esp8266/esp12/espruino/manifest.1.91.json",
+                    "latest": true
+                },
+                {
+                    "version": "1v90",
+                    "board": "ESP8266",
+                    "revision": "ESP12",
+                    "manifest": "/v1/esp8266/esp12/espruino/manifest.1.90.json",
+                    "latest": false
+                },
+                {
                     "version": "1v89",
                     "board": "ESP8266",
                     "revision": "ESP12",
                     "manifest": "/v1/esp8266/esp12/espruino/manifest.1.89.json",
-                    "latest": true
+                    "latest": false
                 },
                 {
                     "version": "1v88",


### PR DESCRIPTION
Updated to the latest Espruino firmware (v91) and included v90 for completeness.